### PR TITLE
supplement unit test case and default dirty parameters

### DIFF
--- a/cocos/core/scene-graph/node-ui-properties.ts
+++ b/cocos/core/scene-graph/node-ui-properties.ts
@@ -104,11 +104,11 @@ export class NodeUIProperties {
      * @en Make the opacity state of node tree is dirty
      * @zh 为结点树的透明度状态设置脏标签
      */
-    public static markOpacityTree (node) {
-        node._uiProps.opacityDirty = true;
+    public static markOpacityTree (node, isDirty = true) {
+        node._uiProps.opacityDirty = isDirty;
         for (let i = 0, l = node.children.length; i < l; i++) {
             const c = node.children[i];
-            NodeUIProperties.markOpacityTree(c);
+            NodeUIProperties.markOpacityTree(c, isDirty);
         }
     }
 }

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -2,8 +2,43 @@ import { Node, Scene } from "../../cocos/core/scene-graph"
 import { Vec3 } from "../../cocos/core/math"
 import { director } from "../../cocos/core";
 import { NodeEventType } from "../../cocos/core/scene-graph/node-event";
+import { NodeUIProperties } from "../../cocos/core/scene-graph/node-ui-properties";
 
 describe(`Node`, () => {
+    test('mark-opacity-tree',() => {
+        let scene = new Scene('scene');
+        let rootNode = new Node('root');
+        let node_1 = new Node('node_1');
+        let node_2 = new Node('node_2');
+        let node_1_1 = new Node('node_1_1');
+        let node_1_2 = new Node('node_1_2');
+        let node_2_1 = new Node('node_2_1');
+        let node_2_2 = new Node('node_2_2');
+        let node_1_1_1 = new Node('node_1_1_1');
+        let node_1_2_1 = new Node('node_1_2_1');
+
+        rootNode.parent = scene;
+        node_1.parent = rootNode;
+        node_2.parent = rootNode;
+        node_1_1.parent = node_1;
+        node_1_2.parent = node_1;
+        node_2_1.parent = node_2;
+        node_2_2.parent = node_2;
+        node_1_1_1.parent = node_1_1;
+        node_1_2_1.parent = node_1_2;
+
+        // set all nodes alpha-dirty to false
+        NodeUIProperties.markOpacityTree(rootNode, false);
+        expect(node_2_1._uiProps.opacityDirty).toStrictEqual(false);
+
+        // modify node_1 and its subtree, node_2 and its subtree are not influenced
+        NodeUIProperties.markOpacityTree(node_1);
+        expect(node_1._uiProps.opacityDirty).toStrictEqual(true);
+        expect(node_1_1._uiProps.opacityDirty).toStrictEqual(true);
+        expect(node_1_2_1._uiProps.opacityDirty).toStrictEqual(true);
+        expect(node_2_2._uiProps.opacityDirty).toStrictEqual(false);
+    });
+
     test('@inverseTransformPoint', () => {
         let scene = new Scene('temp');
         let parentNode = new Node();


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 补充了markOpacityTree的默认dirty参数，默认值是true
 * 补充了单元测试例

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
